### PR TITLE
Remove y from log det jac

### DIFF
--- a/simplex/bijector.py
+++ b/simplex/bijector.py
@@ -51,7 +51,7 @@ class Bijector(object):
         """
         raise NotImplementedError
 
-    def log_abs_det_jacobian(self, x, y, params=None):
+    def log_abs_det_jacobian(self, x, params=None):
         """
         Computes the log det jacobian `log |dy/dx|` given input and output. 
         By default, assumes a volume preserving bijection.

--- a/simplex/bijectors/affine_autoregressive.py
+++ b/simplex/bijectors/affine_autoregressive.py
@@ -52,7 +52,7 @@ class AffineAutoregressive(simplex.Bijector):
         x = torch.stack(x, dim=-1)
         return x
 
-    def log_abs_det_jacobian(self, x, y, params=None):
+    def log_abs_det_jacobian(self, x, params=None):
         # Note: params will take care of caching "mean, log_scale, perm = params(x)"
         _, log_scale, _ = params(x)
         log_scale = clamp_preserve_gradients(log_scale, self.log_scale_min_clip, self.log_scale_max_clip)


### PR DESCRIPTION
I don't think `y` affects the jacobian

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stefanwebb/simplex/4)
<!-- Reviewable:end -->
